### PR TITLE
Script to compare languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/c#/obj
 **/settings.json
 **/rust/target
+**/.vscode/

--- a/coins-on-the-clock/c#/coinsOnTheClock.cs
+++ b/coins-on-the-clock/c#/coinsOnTheClock.cs
@@ -4,144 +4,145 @@ using System.Diagnostics;
 
 namespace coinsOnTheClock
 {
-    class Program
+  class Program
+  {
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-          int modulo = 12;
-          int[] coins = {1, 5, 10};
-          int[] counts = {4, 4, 4};
-          Console.WriteLine("Modulo=" + modulo + "\ncoins=" + string.Join(',', coins) + "\n");
+      int modulo = 12;
+      int[] coins = { 1, 5, 10 };
+      int[] counts = { 4, 4, 4 };
 
-          Stopwatch timer = new Stopwatch();
-          timer.Start();
-          List<string> sequences = GetValidSequences(modulo, coins, counts);
-          timer.Stop();
+      Stopwatch timer = new Stopwatch();
+      timer.Start();
+      for (int i = 0; i < 1000; i += 1) GetValidSequences(modulo, coins, counts);
+      timer.Stop();
 
-          long nanosecPerTick = 1000L*1000L*1000L / Stopwatch.Frequency;
-
-          Console.WriteLine("Elapsed " + (timer.ElapsedTicks * nanosecPerTick) + "ns"); // Got ~1,600,000ns.
-
-          foreach (string sequence in sequences) {
-              System.Console.WriteLine(sequence);
-          }
-        }
-
-        // Gets valid coin sequences
-        // numHours - number of hours on our clock
-        // values   - int array of coin values to add to clock
-        // counts   - count of each coin value. Related to values
-        public static List<string> GetValidSequences(int numHours, int[] values, int[] counts)
-        {
-            bool[] clockState = new bool[numHours];
-            int[] currentSequence = new int[numHours];
-
-            // Get all the sequences
-            List<int[]> sequences = GetValidSequences(
-                numHours,
-                values,
-                counts,
-                currentSequence,
-                clockState
-            );
-
-            // Convert to strings.
-            List<string> results = new List<string>();
-            foreach (int[] sequence in sequences) {
-                char[] result = new char[sequence.Length];
-                for (int i = 0; i < result.Length; i += 1) {
-                    result[i] = GetCoinName(sequence[i]);
-                }
-                results.Add(new string(result));
-            }
-            return results;
-        }
-
-        // Recursive function to get valid coin sequences
-        // numHours             - number of hours on our clock
-        // values               - int array of coin values to add to clock
-        // counts               - count of each coin value. Related to values
-        // currentSequence      - Array of coin values we've placed on the clock
-        // clockState           - Array recording which clock hours have coins
-        // currentValue         - current clock hour we're on
-        // currentSequenceIndex - Current index of sequence we're on
-        static List<int[]> GetValidSequences(
-            int numHours,
-            int[] values,
-            int[] counts,
-            int[] currentSequence,
-            bool[] clockState,
-            int currentValue = 0,
-            int currentSequenceIndex = 0
-        ) {
-            // Store all the sequences we find
-            List<int[]> returnValues = new List<int[]>();
-
-            // If we've added the last coin, record the sequence
-            if (currentSequenceIndex == numHours) {
-                int[] copiedSequence = new int[currentSequence.Length];
-                System.Array.Copy(currentSequence, copiedSequence, currentSequence.Length);
-                returnValues.Add(copiedSequence);
-            }
-            else {
-
-                // We need to build on our current sequence. Get the next coin
-                for (int i = 0; i < values.Length; i += 1) {
-
-                    // If we've used all coins of this type, continue
-                    if (counts[i] == 0) continue;
-
-                    // Get coin value
-                    int value = values[i];
-
-                    // Otherwise, see where this next coin put us
-                    int nextValue = (currentValue + value) % numHours;
-
-                    // If there's already a coin there, move on
-                    if (clockState[nextValue]) continue;
-
-                    // Add the coin to our clock
-                    currentSequence[currentSequenceIndex] = value;
-                    currentSequenceIndex += 1;
-                    clockState[nextValue] = true;
-                    counts[i] -= 1;
-
-                    returnValues.AddRange(GetValidSequences(
-                        numHours,
-                        values,
-                        counts,
-                        currentSequence,
-                        clockState,
-                        nextValue,
-                        currentSequenceIndex
-                    ));
-
-                    // Remove the coin
-                    currentSequenceIndex -= 1;
-                    currentSequence[currentSequenceIndex] = 0;
-                    clockState[nextValue] = false;
-                    counts[i] += 1;
-                }
-            }
-
-            return returnValues;
-        }
-
-        // GetCoinName
-        // Gets char name of coin value
-        // coin - value of coin to get name for
-        // Throws argument exception if coin name is not found
-        public static char GetCoinName(int coin) {
-            switch(coin) {
-                case 1:
-                    return 'p';
-                case 5:
-                    return 'n';
-                case 10:
-                    return 'd';
-                default:
-                    throw new ArgumentException("Invalid US Coin value of " + coin);
-            }
-        }
+      Console.WriteLine(timer.ElapsedMilliseconds);
     }
+
+    // Gets valid coin sequences
+    // numHours - number of hours on our clock
+    // values   - int array of coin values to add to clock
+    // counts   - count of each coin value. Related to values
+    public static List<string> GetValidSequences(int numHours, int[] values, int[] counts)
+    {
+      bool[] clockState = new bool[numHours];
+      int[] currentSequence = new int[numHours];
+
+      // Get all the sequences
+      List<int[]> sequences = GetValidSequences(
+          numHours,
+          values,
+          counts,
+          currentSequence,
+          clockState
+      );
+
+      // Convert to strings.
+      List<string> results = new List<string>();
+      foreach (int[] sequence in sequences)
+      {
+        char[] result = new char[sequence.Length];
+        for (int i = 0; i < result.Length; i += 1)
+        {
+          result[i] = GetCoinName(sequence[i]);
+        }
+        results.Add(new string(result));
+      }
+      return results;
+    }
+
+    // Recursive function to get valid coin sequences
+    // numHours             - number of hours on our clock
+    // values               - int array of coin values to add to clock
+    // counts               - count of each coin value. Related to values
+    // currentSequence      - Array of coin values we've placed on the clock
+    // clockState           - Array recording which clock hours have coins
+    // currentValue         - current clock hour we're on
+    // currentSequenceIndex - Current index of sequence we're on
+    static List<int[]> GetValidSequences(
+        int numHours,
+        int[] values,
+        int[] counts,
+        int[] currentSequence,
+        bool[] clockState,
+        int currentValue = 0,
+        int currentSequenceIndex = 0
+    )
+    {
+      // Store all the sequences we find
+      List<int[]> returnValues = new List<int[]>();
+
+      // If we've added the last coin, record the sequence
+      if (currentSequenceIndex == numHours)
+      {
+        int[] copiedSequence = new int[currentSequence.Length];
+        System.Array.Copy(currentSequence, copiedSequence, currentSequence.Length);
+        returnValues.Add(copiedSequence);
+      }
+      else
+      {
+
+        // We need to build on our current sequence. Get the next coin
+        for (int i = 0; i < values.Length; i += 1)
+        {
+
+          // If we've used all coins of this type, continue
+          if (counts[i] == 0) continue;
+
+          // Get coin value
+          int value = values[i];
+
+          // Otherwise, see where this next coin put us
+          int nextValue = (currentValue + value) % numHours;
+
+          // If there's already a coin there, move on
+          if (clockState[nextValue]) continue;
+
+          // Add the coin to our clock
+          currentSequence[currentSequenceIndex] = value;
+          currentSequenceIndex += 1;
+          clockState[nextValue] = true;
+          counts[i] -= 1;
+
+          returnValues.AddRange(GetValidSequences(
+              numHours,
+              values,
+              counts,
+              currentSequence,
+              clockState,
+              nextValue,
+              currentSequenceIndex
+          ));
+
+          // Remove the coin
+          currentSequenceIndex -= 1;
+          currentSequence[currentSequenceIndex] = 0;
+          clockState[nextValue] = false;
+          counts[i] += 1;
+        }
+      }
+
+      return returnValues;
+    }
+
+    // GetCoinName
+    // Gets char name of coin value
+    // coin - value of coin to get name for
+    // Throws argument exception if coin name is not found
+    public static char GetCoinName(int coin)
+    {
+      switch (coin)
+      {
+        case 1:
+          return 'p';
+        case 5:
+          return 'n';
+        case 10:
+          return 'd';
+        default:
+          throw new ArgumentException("Invalid US Coin value of " + coin);
+      }
+    }
+  }
 }

--- a/coins-on-the-clock/c#/coinsOnTheClock.cs
+++ b/coins-on-the-clock/c#/coinsOnTheClock.cs
@@ -117,7 +117,6 @@ namespace coinsOnTheClock
 
           // Remove the coin
           currentSequenceIndex -= 1;
-          currentSequence[currentSequenceIndex] = 0;
           clockState[nextValue] = false;
           counts[i] += 1;
         }

--- a/coins-on-the-clock/cpp/coins-on-the-clock.cpp
+++ b/coins-on-the-clock/cpp/coins-on-the-clock.cpp
@@ -163,23 +163,16 @@ int main()
   int counts[] = {4, 4, 4};
   int numValues = 3;
 
-  vector<string> values;
-
   // Get the number of ticks it takes for 1000 calculations.
   clock_t t;
   t = clock();
   for (int i = 0; i < 1000; i += 1)
   {
-    values = getValidSequences(numHours, &coins[0], &counts[0], numValues);
+    getValidSequences(numHours, &coins[0], &counts[0], numValues);
   }
   t = clock() - t;
 
-  // Multiple by 1,000,000 to get ticks for 1e9 calculations.
-  // Divide by ticks/sec to get ns/calculation.
-  cout << "Time: " << ((double)t) * 1000 * 1000 / CLOCKS_PER_SEC << "ns" << endl;
-
-  for (int i = 0; i < values.size(); i += 1)
-  {
-    cout << values[i] << endl; // Got ~110,000 ns
-  }
+  // Divide by CLOCKS_PER_SEC to get seconds for 1000 calculations.
+  // Multiple by 1000 to get ms for 1000 calculations.
+  cout << ((double)t) * 1000 / CLOCKS_PER_SEC << endl;
 }

--- a/coins-on-the-clock/cpp/coins-on-the-clock.cpp
+++ b/coins-on-the-clock/cpp/coins-on-the-clock.cpp
@@ -97,7 +97,6 @@ vector<int *> getValidSequences(
 
       // Remove coin
       currentSequenceIndex -= 1;
-      *(currentSequence + currentSequenceIndex) = 0;
       *(clockState + nextValue) = false;
       *(counts + i) += 1;
     }

--- a/coins-on-the-clock/python/coins-on-the-clock.py
+++ b/coins-on-the-clock/python/coins-on-the-clock.py
@@ -67,7 +67,6 @@ def _GetValidSequences(
 
             # Remove the coin from the clock to try the next coin
             currentIndex -= 1
-            currentSequence[currentIndex] = None
             clockState[nextValue] = False
             counts[i] += 1
 

--- a/coins-on-the-clock/python/coins-on-the-clock.py
+++ b/coins-on-the-clock/python/coins-on-the-clock.py
@@ -1,4 +1,4 @@
-from collections import deque
+import itertools
 import time
 
 '''
@@ -11,68 +11,85 @@ counts          - Array of ints. Must be matched with coins. Gives count of each
 clockState      - Array of bools. Lists which clock hours have coins
 currentSequence - List of ints. Current sequence of coins placed
 currentValue    - Int. Current value of clock we're on
+currentIndex    - Int. Current index of currentSequence we're on
+coinLength      - Length of coins array
 '''
+
+
 def _GetValidSequences(
-  numHours,
-  coins,
-  counts,
-  clockState,
-  currentSequence,
-  currentValue
+    numHours,
+    coins,
+    counts,
+    clockState,
+    currentSequence,
+    currentValue,
+    currentIndex,
+    coinLength
 ):
-  returnValues = []
+    returnValues = []
 
-  # If we have numHours coins in our sequence, we've
-  # found a solution. Add it to returnValues.
-  if (len(currentSequence) == numHours):
-    returnValues.append(currentSequence[:])
-  else:
-    for i in range(len(coins)):
+    # If we have numHours coins in our sequence, we've
+    # found a solution. Add it to returnValues.
+    if (currentIndex == numHours):
+        returnValues.append(currentSequence[:])
+    else:
+        for i in range(coinLength):
 
-      # If we ran out of this coin, continue
-      if counts[i] == 0:
-        continue
+            # If we ran out of this coin, continue
+            if counts[i] == 0:
+                continue
 
-      # Determine where the next coin would go
-      coinValue = coins[i]
-      nextValue = (currentValue + coinValue) % numHours
+            # Determine where the next coin would go
+            coinValue = coins[i]
+            nextValue = (currentValue + coinValue) % numHours
 
-      # If there's already a coin there, continue
-      if clockState[nextValue]:
-        continue
+            # If there's already a coin there, continue
+            if clockState[nextValue]:
+                continue
 
-      # Place the coin on the clock
-      currentSequence.append(coinValue)
-      clockState[nextValue] = True
-      counts[i] -= 1
+            # Place the coin on the clock
+            currentSequence[currentIndex] = coinValue
+            currentIndex += 1
+            clockState[nextValue] = True
+            counts[i] -= 1
 
-      # Recurse
-      returnValues.extend(_GetValidSequences(
-        numHours,
-        coins,
-        counts,
-        clockState,
-        currentSequence,
-        nextValue
-      ))
+            # Recurse
+            returnValues.extend(_GetValidSequences(
+                numHours,
+                coins,
+                counts,
+                clockState,
+                currentSequence,
+                nextValue,
+                currentIndex,
+                coinLength
+            ))
 
-      # Remove the coin from the clock to try the next coin
-      currentSequence.pop()
-      clockState[nextValue] = False
-      counts[i] += 1
+            # Remove the coin from the clock to try the next coin
+            currentIndex -= 1
+            currentSequence[currentIndex] = None
+            clockState[nextValue] = False
+            counts[i] += 1
 
-  return returnValues
+    return returnValues
+
 
 '''
 GetCoinName
 Returns character that is the name of the coin based on the given value
 value - value of coin to get character of
 '''
+
+
 def GetCoinName(value):
-  if value == 1: return 'p'
-  if value == 5: return 'n'
-  if value == 10: return 'd'
-  return '?'
+    if value == 1:
+        return 'p'
+    if value == 5:
+        return 'n'
+    if value == 10:
+        return 'd'
+    return '?'
+
 
 '''
 GetValidSequences
@@ -81,39 +98,47 @@ numHours        - Int. Number of hours on the clock
 coins           - Array of ints. Must be matched with counts. Gives value of each coin
 counts          - Array of ints. Must be matched with coins. Gives count of each coin
 '''
+
+
 def GetValidSequences(numHours, coins, counts):
-  clockState = [False] * numHours
-  currentSequence = []
+    clockState = [False] * numHours
+    currentSequence = [None] * numHours
 
-  sequences = _GetValidSequences(
-    numHours,
-    coins,
-    counts,
-    clockState,
-    currentSequence,
-    0
-  )
+    sequences = _GetValidSequences(
+        numHours,
+        coins,
+        counts,
+        clockState,
+        currentSequence,
+        0,
+        0,
+        len(coins)
+    )
 
-  # Convert list of list of ints to list of strings
-  # The list generator takes the list of ints and generates
-  # a list of coin names. ''.join() joins those into a single string
-  for i in range(len(sequences)):
-    sequences[i] = ''.join([GetCoinName(coinValue) for coinValue in sequences[i]])
+    # Convert list of list of ints to list of strings
+    returnValue = [IntListToString(sequence) for sequence in sequences]
 
-  return sequences
+    return returnValue
 
 
-def main ():
-  numHours = 12
-  coins = [1, 5, 10]
-  counts = [4, 4, 4]
-  print(f'Number of hours = {numHours}\nCoins = {coins}\nCounts = {counts}')
+def IntListToString(intList):
+    return ''.join([GetCoinName(i) for i in intList])
 
-  start = time.time()
-  sequences = GetValidSequences(numHours, coins, counts)
-  end = 1000 * 1000 * 1000 * (time.time() - start)
-  print(f'{end} ns') # ~5,000,000 ns Python 3 64 bit
-                     # ~6,500,000 ns Python 3 32 bit
-  print(sequences)
+
+def main():
+    numHours = 12
+    coins = [1, 5, 10]
+    counts = [4, 4, 4]
+
+    start = time.time()
+    for _ in itertools.repeat(None, 1000):
+        GetValidSequences(numHours, coins, counts)
+    end = time.time()
+
+    # time.time() gives us difference in seconds.
+    # Multiply by 1000 to get ms
+    total = 1000 * (end - start)
+    print(total)
+
 
 main()

--- a/coins-on-the-clock/ruby/coins_on_the_clock.rb
+++ b/coins-on-the-clock/ruby/coins_on_the_clock.rb
@@ -1,10 +1,16 @@
-def get_valid_sequences(
+def get_valid_sequences(num_hours, values, counts)
+  sequences = _get_valid_sequences(num_hours, values, counts, [], [], 0)
+
+  sequences.map { |s| s.map { |i| get_coin_name(i) }.join('') }
+end
+
+def _get_valid_sequences(
   num_hours,
   values,
   counts,
-  current_sequence = [],
-  clock_state = [],
-  current_value = 0
+  current_sequence,
+  clock_state,
+  current_value
 )
   return [current_sequence.dup] if current_sequence.length == num_hours
 
@@ -20,7 +26,7 @@ def get_valid_sequences(
     counts[i] -= 1
     current_sequence.push values[i]
 
-    return_values.concat(get_valid_sequences(
+    return_values.concat(_get_valid_sequences(
       num_hours,
       values,
       counts,
@@ -54,12 +60,11 @@ end
 modulo = 12
 coins = [ 1, 5, 10 ]
 counts = [ 4, 4, 4 ]
-puts "Modulo=#{modulo}\ncoins=#{coins.join(", ")}"
 
 start = Time.now
-sequences = get_valid_sequences(modulo, coins, counts)
+1000.times { get_valid_sequences(modulo, coins, counts) }
 stop = Time.now
 
-puts "Elapsed #{((stop - start) * 1_000_000_000).round} ns (ish)"
-
-pp sequences.map { |list| list.map { |value| get_coin_name(value) }.join("") }
+# stop - start is time in seconds.
+# Multipley by 1000 to get ms for 1000 calculations.
+puts ((stop - start) * 1_000)

--- a/coins-on-the-clock/rust/src/main.rs
+++ b/coins-on-the-clock/rust/src/main.rs
@@ -6,11 +6,13 @@ fn main() {
     let counts = [4, 4, 4];
 
     let now = time::precise_time_ns();
-    let valid_sequences = get_valid_sequences(num_hours, &coins, &counts);
+    for _ in 0..1000 {
+        get_valid_sequences(num_hours, &coins, &counts);
+    }
     let now2 = time::precise_time_ns();
-    let diff = (now2 - now) / 1000;
+    let diff = (now2 - now) / 1000000;
 
-    println!("DONE: {} ms, Values = {:?}", diff, valid_sequences);
+    println!("{}", diff);
 }
 
 fn get_valid_sequences(num_hours: usize, coins: &[usize], counts: &[usize]) -> Vec<String> {

--- a/coins-on-the-clock/test-all.rb
+++ b/coins-on-the-clock/test-all.rb
@@ -1,0 +1,20 @@
+python_ms = `python3 python/coins-on-the-clock.py`
+
+cpp_compile = `g++ -O3 cpp/coins-on-the-clock.cpp -o "cpp/coins-on-the-clock"`
+cpp_ms = `cpp/coins-on-the-clock`
+cpp_cleanup = `rm cpp/coins-on-the-clock`
+
+ruby_ms = `ruby ruby/coins_on_the_clock.rb`
+
+cs_ms = `dotnet run -c Release --project c#/`
+
+rust_ms = `cd rust && cargo run --release rust/src/main.rs && cd ../`
+
+puts "OUTPUT (ms for 1000 iterations):"
+[
+  [ "python", python_ms ],
+  [ "cpp", cpp_ms ],
+  [ "ruby", ruby_ms ],
+  [ "cs", cs_ms ],
+  [ "rust", rust_ms ],
+].sort_by { |_, ms| ms.to_f }.each { |lang, ms| puts "#{lang}:\t#{ms}" }


### PR DESCRIPTION
* Adds ruby script for performance comparing each language for coins-on-the-clock
* Updates python for some optimizations that maybe make sense
* Updates ruby to have the correct return value (it was cheating by returning a list of list of ints instead of a list of strings)
* Updates other languages to not reset `currentSequence[currentSequenceIndex]` because that doesn't affect the output and it's a waste of time
* Updates python script to format to PEP8 standards.

Addresses issue #4 