### PR TITLE
CotC - Passes return values through recursive function

### DIFF
--- a/coins-on-the-clock/c#/coinsOnTheClock.cs
+++ b/coins-on-the-clock/c#/coinsOnTheClock.cs
@@ -30,12 +30,14 @@ namespace coinsOnTheClock
       int[] currentSequence = new int[numHours];
 
       // Get all the sequences
-      List<int[]> sequences = GetValidSequences(
+      List<int[]> sequences = new List<int[]>();
+      GetValidSequences(
           numHours,
           values,
           counts,
           currentSequence,
-          clockState
+          clockState,
+          sequences
       );
 
       // Convert to strings.
@@ -58,26 +60,25 @@ namespace coinsOnTheClock
     // counts               - count of each coin value. Related to values
     // currentSequence      - Array of coin values we've placed on the clock
     // clockState           - Array recording which clock hours have coins
+    // returnValues         - List of sequence results (int[]s)
     // currentValue         - current clock hour we're on
     // currentSequenceIndex - Current index of sequence we're on
-    static List<int[]> GetValidSequences(
+    static void GetValidSequences(
         int numHours,
         int[] values,
         int[] counts,
         int[] currentSequence,
         bool[] clockState,
+        List<int[]> returnValues,
         int currentValue = 0,
         int currentSequenceIndex = 0
     )
     {
-      // Store all the sequences we find
-      List<int[]> returnValues = new List<int[]>();
-
       // If we've added the last coin, record the sequence
       if (currentSequenceIndex == numHours)
       {
         int[] copiedSequence = new int[currentSequence.Length];
-        System.Array.Copy(currentSequence, copiedSequence, currentSequence.Length);
+        Array.Copy(currentSequence, copiedSequence, currentSequence.Length);
         returnValues.Add(copiedSequence);
       }
       else
@@ -104,27 +105,22 @@ namespace coinsOnTheClock
           clockState[nextValue] = true;
           counts[i] -= 1;
 
-          List<int[]> sequences = GetValidSequences(
+          GetValidSequences(
               numHours,
               values,
               counts,
               currentSequence,
               clockState,
+              returnValues,
               nextValue,
               currentSequenceIndex + 1
           );
-          if (sequences.Count > 0)
-          {
-            returnValues.AddRange(sequences);
-          }
 
           // Remove the coin
           clockState[nextValue] = false;
           counts[i] += 1;
         }
       }
-
-      return returnValues;
     }
 
     // GetCoinName

--- a/coins-on-the-clock/cpp/coins-on-the-clock.cpp
+++ b/coins-on-the-clock/cpp/coins-on-the-clock.cpp
@@ -30,31 +30,28 @@ char getCoinName(int value)
 // numValues            - number of different coin values we have
 // currentSequence      - array of coin values we've placed
 // clockState           - for each clock hour, true if a coin is on it
+// returnValues         - reference to vector for pushing complete sequences
 // currentValue         - current clock hour we're on
 // currentSequenceIndex - index of currentSequence we're on
-vector<int *> getValidSequences(
+void getValidSequences(
     int numHours,
     int *values,
     int *counts,
     int numValues,
     int *currentSequence,
     bool *clockState,
+    vector<int *> *returnValues,
     int currentValue,
     int currentSequenceIndex)
 {
-  vector<int *> returnValues;
-
   // If we're on the last hour, we have a valid sequence
   if (currentSequenceIndex == numHours)
   {
 
     // Copy the array and push it onto the vector
     int *copiedSequence = new int[numHours];
-    for (int i = 0; i < numHours; i += 1)
-    {
-      *(copiedSequence + i) = *(currentSequence + i);
-    }
-    returnValues.push_back(copiedSequence);
+    memcpy(copiedSequence, currentSequence, numHours * sizeof (int));
+    returnValues->push_back(copiedSequence);
   }
   else
   {
@@ -81,26 +78,22 @@ vector<int *> getValidSequences(
       *(counts + i) -= 1;
 
       // Recurse
-      vector<int *> recursedValues = getValidSequences(
+      getValidSequences(
           numHours,
           values,
           counts,
           numValues,
           currentSequence,
           clockState,
+          returnValues,
           nextValue,
           currentSequenceIndex + 1);
-
-      // Concatenate vectors
-      returnValues.insert(returnValues.end(), recursedValues.begin(), recursedValues.end());
 
       // Remove coin
       *(clockState + nextValue) = false;
       *(counts + i) += 1;
     }
   }
-
-  return returnValues;
 }
 
 // Gets vector of strings of valid coin sequences
@@ -119,13 +112,15 @@ vector<string> getValidSequences(
   bool *clockState = new bool[numHours]();
   int *currentSequence = new int[numHours];
 
-  vector<int *> sequences = getValidSequences(
+  vector<int *> sequences;
+  getValidSequences(
       numHours,
       values,
       counts,
       numValues,
       currentSequence,
       clockState,
+      &sequences,
       0,
       0);
 

--- a/coins-on-the-clock/js/coins_on_the_clock.js
+++ b/coins-on-the-clock/js/coins_on_the_clock.js
@@ -1,12 +1,14 @@
 const performance = require("perf_hooks").performance;
 
 function getValidSequences(numHours, values, counts) {
-  const sequences = _getValidSequences(
+  const sequences = [];
+  _getValidSequences(
     numHours,
     values,
     counts,
     Buffer.alloc(numHours),
     Buffer.alloc(numHours),
+    sequences,
     0,
     0
   );
@@ -19,39 +21,40 @@ function _getValidSequences(
   counts,
   currentSequence,
   clockState,
+  returnValues,
   currentValue,
   currentSequenceIndex
 ) {
-  if (currentSequenceIndex === numHours) return [[...currentSequence]];
-
-  const returnValues = [];
-  for (let i = 0; i < counts.length; i++) {
-    if (counts[i] === 0) continue;
-
-    const nextValue = (currentValue + values[i]) % numHours;
-
-    if (clockState[nextValue]) continue;
-
-    clockState[nextValue] = 1;
-    counts[i] -= 1;
-    currentSequence[currentSequenceIndex] = values[i];
-
-    const sequences = _getValidSequences(
-      numHours,
-      values,
-      counts,
-      currentSequence,
-      clockState,
-      nextValue,
-      currentSequenceIndex + 1
-    );
-    if (sequences.length) returnValues.push(...sequences);
-
-    clockState[nextValue] = 0;
-    counts[i] += 1;
+  if (currentSequenceIndex === numHours) {
+    returnValues.push([...currentSequence]);
   }
+  else {
+    for (let i = 0; i < counts.length; i++) {
+      if (counts[i] === 0) continue;
 
-  return returnValues;
+      const nextValue = (currentValue + values[i]) % numHours;
+
+      if (clockState[nextValue]) continue;
+
+      clockState[nextValue] = 1;
+      counts[i] -= 1;
+      currentSequence[currentSequenceIndex] = values[i];
+
+      const sequences = _getValidSequences(
+        numHours,
+        values,
+        counts,
+        currentSequence,
+        clockState,
+        returnValues,
+        nextValue,
+        currentSequenceIndex + 1
+      );
+
+      clockState[nextValue] = 0;
+      counts[i] += 1;
+    }
+  }
 }
 
 function getCoinName(coin) {

--- a/coins-on-the-clock/kotlin/coins_on_the_clock.kt
+++ b/coins-on-the-clock/kotlin/coins_on_the_clock.kt
@@ -14,12 +14,14 @@ fun main(args: Array<String>) {
 }
 
 fun getValidSequences(numHours: Int, values: IntArray, counts: IntArray): List<String> {
-  val sequences = getValidSequences(
+  val sequences = mutableListOf<IntArray>()
+  getValidSequences(
     numHours,
     values,
     counts,
     IntArray(numHours),
     BooleanArray(numHours),
+    sequences,
     0,
     0
   )
@@ -33,11 +35,10 @@ fun getValidSequences(
   counts: IntArray,
   currentSequence: IntArray,
   clockState: BooleanArray,
+  returnValues: MutableList<IntArray>,
   currentValue: Int,
   currentSequenceIndex: Int
-): MutableList<IntArray> {
-  val returnValues = mutableListOf<IntArray>()
-
+) {
   if (currentSequenceIndex == numHours) {
     returnValues.add(currentSequence.copyOf())
   } else {
@@ -55,25 +56,21 @@ fun getValidSequences(
       clockState[nextValue] = true
       counts[i] -= 1
 
-      val sequences = getValidSequences(
-          numHours,
-          values,
-          counts,
-          currentSequence,
-          clockState,
-          nextValue,
-          currentSequenceIndex + 1
+      getValidSequences(
+        numHours,
+        values,
+        counts,
+        currentSequence,
+        clockState,
+        returnValues,
+        nextValue,
+        currentSequenceIndex + 1
       )
-      for (sequence in sequences) {
-        returnValues.add(sequence)
-      }
 
       clockState[nextValue] = false
       counts[i] += 1
     }
   }
-
-  return returnValues
 }
 
 fun getCoinName(i: Int): Char {

--- a/coins-on-the-clock/python/coins-on-the-clock.py
+++ b/coins-on-the-clock/python/coins-on-the-clock.py
@@ -9,6 +9,7 @@ numHours        - Int. Number of hours on the clock
 coins           - Array of ints. Must be matched with counts. Gives value of each coin
 counts          - Array of ints. Must be matched with coins. Gives count of each coin
 clockState      - Array of bools. Lists which clock hours have coins
+returnValues    - Reference to a list to push solutions onto
 currentSequence - List of ints. Current sequence of coins placed
 currentValue    - Int. Current value of clock we're on
 currentIndex    - Int. Current index of currentSequence we're on
@@ -21,13 +22,12 @@ def _GetValidSequences(
     coins,
     counts,
     clockState,
+    returnValues,
     currentSequence,
     currentValue,
     currentIndex,
     coinLength
 ):
-    returnValues = []
-
     # If we have numHours coins in our sequence, we've
     # found a solution. Add it to returnValues.
     if (currentIndex == numHours):
@@ -58,20 +58,16 @@ def _GetValidSequences(
                 coins,
                 counts,
                 clockState,
+                returnValues,
                 currentSequence,
                 nextValue,
                 currentIndex + 1,
                 coinLength
             )
 
-            if sequences:
-                returnValues.extend(sequences)
-
             # Remove the coin from the clock to try the next coin
             clockState[nextValue] = False
             counts[i] += 1
-
-    return returnValues
 
 
 '''
@@ -104,11 +100,13 @@ def GetValidSequences(numHours, coins, counts):
     clockState = [False] * numHours
     currentSequence = [None] * numHours
 
-    sequences = _GetValidSequences(
+    sequences = []
+    _GetValidSequences(
         numHours,
         coins,
         counts,
         clockState,
+        sequences,
         currentSequence,
         0,
         0,

--- a/coins-on-the-clock/ruby/coins_on_the_clock.rb
+++ b/coins-on-the-clock/ruby/coins_on_the_clock.rb
@@ -1,10 +1,12 @@
 def get_valid_sequences(num_hours, values, counts)
-  sequences = _get_valid_sequences(
+  sequences = []
+  _get_valid_sequences(
     num_hours,
     values,
     counts,
     Array.new(num_hours, 0),
     Array.new(num_hours, false),
+    sequences,
     0,
     0
   )
@@ -18,40 +20,40 @@ def _get_valid_sequences(
   counts,
   current_sequence,
   clock_state,
+  return_values,
   current_value,
   current_sequence_index
 )
-  return [current_sequence.dup] if current_sequence_index == num_hours
+  if current_sequence_index == num_hours
+    return_values.push(current_sequence.dup)
+  else
+    i = -1
+    while ((i += 1) < counts.length) do
+      next if counts[i] == 0
 
-  return_values = []
-  i = -1
-  while ((i += 1) < counts.length) do
-    next if counts[i] == 0
+      next_value = (current_value + values[i]) % num_hours
 
-    next_value = (current_value + values[i]) % num_hours
+      next if clock_state[next_value]
 
-    next if clock_state[next_value]
+      clock_state[next_value] = true
+      counts[i] -= 1
+      current_sequence[current_sequence_index] = values[i]
 
-    clock_state[next_value] = true
-    counts[i] -= 1
-    current_sequence[current_sequence_index] = values[i]
+      _get_valid_sequences(
+        num_hours,
+        values,
+        counts,
+        current_sequence,
+        clock_state,
+        return_values,
+        next_value,
+        current_sequence_index + 1
+      )
 
-    sequences = _get_valid_sequences(
-      num_hours,
-      values,
-      counts,
-      current_sequence,
-      clock_state,
-      next_value,
-      current_sequence_index + 1
-    )
-    return_values.concat(sequences) if sequences.length > 0
-
-    clock_state[next_value] = false
-    counts[i] += 1
+      clock_state[next_value] = false
+      counts[i] += 1
+    end
   end
-
-  return_values
 end
 
 def get_coin_name(coin)

--- a/coins-on-the-clock/rust/Cargo.lock
+++ b/coins-on-the-clock/rust/Cargo.lock
@@ -9,12 +9,12 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.53"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -22,8 +22,8 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -47,8 +47,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "ec350a9417dfd244dc9a6c4a71e13895a4db6b92f0b106f07ebbc3f3bc580cee"
-"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
+"checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/coins-on-the-clock/rust/src/main.rs
+++ b/coins-on-the-clock/rust/src/main.rs
@@ -19,18 +19,20 @@ fn get_valid_sequences(num_hours: usize, coins: &[usize], counts: &[usize]) -> V
     let mut clock_state = vec![false; num_hours];
     let mut current_sequence = Vec::with_capacity(num_hours);
 
-    let sequences = _get_valid_sequences_with_defaults(
+    let mut sequences = Vec::new();
+    _get_valid_sequences_with_defaults(
         num_hours,
         coins,
         counts,
         &mut current_sequence,
         &mut clock_state,
-    )
-    .into_iter()
-    .map(|value_vec| usize_vec_to_string(value_vec))
-    .collect();
+        &mut sequences,
+    );
 
-    return sequences;
+    return sequences
+        .into_iter()
+        .map(|value_vec| usize_vec_to_string(value_vec))
+        .collect();
 }
 
 fn usize_vec_to_string(values: Vec<usize>) -> String {
@@ -46,13 +48,15 @@ fn _get_valid_sequences_with_defaults(
     counts: &[usize],
     current_sequence: &mut Vec<usize>,
     clock_state: &mut Vec<bool>,
-) -> Vec<Vec<usize>> {
-    return _get_valid_sequences(
+    return_values: &mut Vec<Vec<usize>>,
+) {
+    _get_valid_sequences(
         num_hours,
         coins,
         counts,
         current_sequence,
         clock_state,
+        return_values,
         0,
         &mut vec![0; counts.len()],
     );
@@ -64,14 +68,12 @@ fn _get_valid_sequences(
     counts: &[usize],
     current_sequence: &mut Vec<usize>,
     clock_state: &mut Vec<bool>,
+    return_values: &mut Vec<Vec<usize>>,
     current_value: usize,
     current_counts: &mut Vec<usize>,
-) -> Vec<Vec<usize>> {
-    let mut return_values = Vec::new();
-
+) {
     if current_sequence.len() == num_hours {
         return_values.push(current_sequence.to_owned());
-        return return_values;
     } else {
         for i in 0..coins.len() {
             let counts_remaining = counts[i] - current_counts[i];
@@ -91,23 +93,22 @@ fn _get_valid_sequences(
             current_counts[i] += 1;
             current_sequence.push(coin);
 
-            let mut new_values = _get_valid_sequences(
+            _get_valid_sequences(
                 num_hours,
                 coins,
                 counts,
                 current_sequence,
                 clock_state,
+                return_values,
                 next_value,
                 current_counts,
             );
-            return_values.append(&mut new_values);
 
             clock_state[next_value] = false;
             current_counts[i] -= 1;
             current_sequence.pop();
         }
     }
-    return return_values;
 }
 
 fn get_coin_name(coin_value: usize) -> char {


### PR DESCRIPTION
My friend Chris told me "allocations are expensive" so I updated my "coins on the clock" program. Instead of each instance of the "get valid sequences" function creating its own array/vector for pushing on (and ultimately returning) solutions, the driver creates an array/vector and passes a reference to it through the rest of the program and the "get valid sequences" function just pushes on solutions when it finds them.

I also didn't do this in `go` because I couldn't figure it out

Overall times (ms):

Language | Before | After
----------|--------|--------
rust | 94       | 65
cs | 107        | 65
cpp | 84 | 66
js | 133 | 108
kotlin | 160 | 114
go | 134 | 132
ruby | 1166 | 1027
python | 2977 | 2990