### PR TITLE
Update API of inner method to be less weird

### DIFF
--- a/coins-on-the-clock/c#/coinsOnTheClock.cs
+++ b/coins-on-the-clock/c#/coinsOnTheClock.cs
@@ -30,7 +30,7 @@ namespace coinsOnTheClock
       int[] currentSequence = new int[numHours];
 
       // Get all the sequences
-      List<int[]> sequences = new List<int[]>();
+      List<string> sequences = new List<string>();
       GetValidSequences(
           numHours,
           values,
@@ -40,18 +40,7 @@ namespace coinsOnTheClock
           sequences
       );
 
-      // Convert to strings.
-      List<string> results = new List<string>();
-      foreach (int[] sequence in sequences)
-      {
-        char[] result = new char[sequence.Length];
-        for (int i = 0; i < result.Length; i += 1)
-        {
-          result[i] = GetCoinName(sequence[i]);
-        }
-        results.Add(new string(result));
-      }
-      return results;
+      return sequences;
     }
 
     // Recursive function to get valid coin sequences
@@ -60,7 +49,7 @@ namespace coinsOnTheClock
     // counts               - count of each coin value. Related to values
     // currentSequence      - Array of coin values we've placed on the clock
     // clockState           - Array recording which clock hours have coins
-    // returnValues         - List of sequence results (int[]s)
+    // returnValues         - List of sequence results
     // currentValue         - current clock hour we're on
     // currentSequenceIndex - Current index of sequence we're on
     static void GetValidSequences(
@@ -69,7 +58,7 @@ namespace coinsOnTheClock
         int[] counts,
         int[] currentSequence,
         bool[] clockState,
-        List<int[]> returnValues,
+        List<string> returnValues,
         int currentValue = 0,
         int currentSequenceIndex = 0
     )
@@ -77,9 +66,11 @@ namespace coinsOnTheClock
       // If we've added the last coin, record the sequence
       if (currentSequenceIndex == numHours)
       {
-        int[] copiedSequence = new int[currentSequence.Length];
-        Array.Copy(currentSequence, copiedSequence, currentSequence.Length);
-        returnValues.Add(copiedSequence);
+        char[] coinNames = new char[currentSequence.Length];
+        for (int i = 0; i < currentSequence.Length; i += 1) {
+          coinNames[i] = GetCoinName(currentSequence[i]);
+        }
+        returnValues.Add(new string(coinNames));
       }
       else
       {

--- a/coins-on-the-clock/cpp/coins-on-the-clock.cpp
+++ b/coins-on-the-clock/cpp/coins-on-the-clock.cpp
@@ -40,7 +40,7 @@ void getValidSequences(
     int numValues,
     int *currentSequence,
     bool *clockState,
-    vector<int *> *returnValues,
+    vector<string> *returnValues,
     int currentValue,
     int currentSequenceIndex)
 {
@@ -49,9 +49,13 @@ void getValidSequences(
   {
 
     // Copy the array and push it onto the vector
-    int *copiedSequence = new int[numHours];
-    memcpy(copiedSequence, currentSequence, numHours * sizeof (int));
-    returnValues->push_back(copiedSequence);
+    char *newSequence = new char[numHours];
+    for (int i = 0; i < numHours; i += 1)
+    {
+      *(newSequence + i) = getCoinName(*(currentSequence + i));
+    }
+    string newSequenceString = newSequence;
+    returnValues->push_back(newSequenceString);
   }
   else
   {
@@ -112,7 +116,7 @@ vector<string> getValidSequences(
   bool *clockState = new bool[numHours]();
   int *currentSequence = new int[numHours];
 
-  vector<int *> sequences;
+  vector<string> sequences;
   getValidSequences(
       numHours,
       values,
@@ -127,25 +131,7 @@ vector<string> getValidSequences(
   delete[] clockState;
   delete[] currentSequence;
 
-  // Convert to char vector
-  vector<string> results(sequences.size());
-  for (int i = 0; i < sequences.size(); i += 1)
-  {
-    int *sequence = sequences[i];
-    char *result = new char[numHours + 1];
-    for (int j = 0; j < numHours; j += 1)
-    {
-      *(result + j) = getCoinName(*(sequence + j));
-    }
-    *(result + numHours) = '\0';
-
-    string stringResult = result;
-    results[i] = stringResult;
-    delete[] result;
-    delete[] sequence;
-  }
-
-  return results;
+  return sequences;
 }
 
 int main()

--- a/coins-on-the-clock/go/coins_on_the_clock.go
+++ b/coins-on-the-clock/go/coins_on_the_clock.go
@@ -22,28 +22,19 @@ func getValidSequences(numHours int, coinValues []int, coinCounts []int) []strin
 	clockState := make([]bool, numHours)
 	currentSequence := make([]int, numHours)
 
-	sequences := _getValidSequences(
+	var sequences []string
+	_getValidSequences(
 		numHours,
 		coinValues,
 		coinCounts,
 		currentSequence,
 		clockState,
+		sequences,
 		0,
 		0,
 	)
 
-	returnValues := make([]string, len(sequences))
-
-	for i, sequence := range sequences {
-		toBeString := make([]byte, len(sequence))
-
-		for j, b := range sequence {
-			toBeString[j] = getCoinName(b)
-		}
-		returnValues[i] = string(toBeString)
-	}
-
-	return returnValues
+	return sequences
 }
 
 func _getValidSequences(
@@ -52,14 +43,16 @@ func _getValidSequences(
 	coinCounts []int,
 	currentSequence []int,
 	clockState []bool,
+	returnValues []string,
 	currentValue int,
 	currentSequenceIndex int,
-) [][]int {
-	var returnValues [][]int
+) {
 	if currentSequenceIndex == numHours {
-		destination := make([]int, numHours)
-		copy(destination, currentSequence)
-		returnValues = append(returnValues, destination)
+		coinNames := make([]byte, numHours)
+		for i, v := range currentSequence {
+			coinNames[i] = getCoinName(v)
+		}
+		returnValues = append(returnValues, string(coinNames))
 	} else {
 		for i := 0; i < len(coinValues); i++ {
 			if coinCounts[i] == 0 {
@@ -76,26 +69,21 @@ func _getValidSequences(
 			clockState[nextValue] = true
 			coinCounts[i]--
 
-			sequences := _getValidSequences(
+			_getValidSequences(
 				numHours,
 				coinValues,
 				coinCounts,
 				currentSequence,
 				clockState,
+				returnValues,
 				nextValue,
 				currentSequenceIndex+1,
 			)
-
-			for _, sequence := range sequences {
-				returnValues = append(returnValues, sequence)
-			}
 
 			clockState[nextValue] = false
 			coinCounts[i]++
 		}
 	}
-
-	return returnValues
 }
 
 func getCoinName(coin int) byte {

--- a/coins-on-the-clock/js/coins_on_the_clock.js
+++ b/coins-on-the-clock/js/coins_on_the_clock.js
@@ -12,7 +12,7 @@ function getValidSequences(numHours, values, counts) {
     0,
     0
   );
-  return sequences.map(sequence => sequence.map(i => getCoinName(i)).join(""));
+  return sequences
 }
 
 function _getValidSequences(
@@ -26,7 +26,7 @@ function _getValidSequences(
   currentSequenceIndex
 ) {
   if (currentSequenceIndex === numHours) {
-    returnValues.push([...currentSequence]);
+    returnValues.push(currentSequence.map(v => getCoinName(v)).join(""));
   }
   else {
     for (let i = 0; i < counts.length; i++) {
@@ -40,7 +40,7 @@ function _getValidSequences(
       counts[i] -= 1;
       currentSequence[currentSequenceIndex] = values[i];
 
-      const sequences = _getValidSequences(
+      _getValidSequences(
         numHours,
         values,
         counts,

--- a/coins-on-the-clock/kotlin/coins_on_the_clock.kt
+++ b/coins-on-the-clock/kotlin/coins_on_the_clock.kt
@@ -14,7 +14,7 @@ fun main(args: Array<String>) {
 }
 
 fun getValidSequences(numHours: Int, values: IntArray, counts: IntArray): List<String> {
-  val sequences = mutableListOf<IntArray>()
+  val sequences = mutableListOf<String>()
   getValidSequences(
     numHours,
     values,
@@ -26,7 +26,7 @@ fun getValidSequences(numHours: Int, values: IntArray, counts: IntArray): List<S
     0
   )
 
-  return sequences.map { sequence -> sequence.map { getCoinName(it) }.joinToString("") }
+  return sequences
 }
 
 fun getValidSequences(
@@ -35,12 +35,12 @@ fun getValidSequences(
   counts: IntArray,
   currentSequence: IntArray,
   clockState: BooleanArray,
-  returnValues: MutableList<IntArray>,
+  returnValues: MutableList<String>,
   currentValue: Int,
   currentSequenceIndex: Int
 ) {
   if (currentSequenceIndex == numHours) {
-    returnValues.add(currentSequence.copyOf())
+    returnValues.add(currentSequence.map { getCoinName(it) }.joinToString(""))
   } else {
     var i = counts.size
     while (--i > -1) {

--- a/coins-on-the-clock/python/coins-on-the-clock.py
+++ b/coins-on-the-clock/python/coins-on-the-clock.py
@@ -31,7 +31,7 @@ def _GetValidSequences(
     # If we have numHours coins in our sequence, we've
     # found a solution. Add it to returnValues.
     if (currentIndex == numHours):
-        returnValues.append(currentSequence[:])
+        returnValues.append(''.join([GetCoinName(v) for v in currentSequence]))
     else:
         for i in range(coinLength):
 
@@ -113,14 +113,7 @@ def GetValidSequences(numHours, coins, counts):
         len(coins)
     )
 
-    # Convert list of list of ints to list of strings
-    returnValue = [IntListToString(sequence) for sequence in sequences]
-
-    return returnValue
-
-
-def IntListToString(intList):
-    return ''.join([GetCoinName(i) for i in intList])
+    return sequences
 
 
 def main():

--- a/coins-on-the-clock/ruby/coins_on_the_clock.rb
+++ b/coins-on-the-clock/ruby/coins_on_the_clock.rb
@@ -11,7 +11,7 @@ def get_valid_sequences(num_hours, values, counts)
     0
   )
 
-  sequences.map { |s| s.map { |i| get_coin_name(i) }.join('') }
+  sequences
 end
 
 def _get_valid_sequences(
@@ -25,7 +25,7 @@ def _get_valid_sequences(
   current_sequence_index
 )
   if current_sequence_index == num_hours
-    return_values.push(current_sequence.dup)
+    return_values.push(current_sequence.map { |i| get_coin_name(i) }.join(''))
   else
     i = -1
     while ((i += 1) < counts.length) do

--- a/coins-on-the-clock/rust/src/main.rs
+++ b/coins-on-the-clock/rust/src/main.rs
@@ -5,12 +5,12 @@ fn main() {
     let coins = [1, 5, 10];
     let counts = [4, 4, 4];
 
-    let now = time::precise_time_ns();
+    let start = time::precise_time_ns();
     for _ in 0..1000 {
         get_valid_sequences(num_hours, &coins, &counts);
     }
-    let now2 = time::precise_time_ns();
-    let diff = (now2 - now) / 1000000;
+    let end = time::precise_time_ns();
+    let diff = (end - start) / 1_000_000;
 
     println!("{}", diff);
 }
@@ -29,17 +29,7 @@ fn get_valid_sequences(num_hours: usize, coins: &[usize], counts: &[usize]) -> V
         &mut sequences,
     );
 
-    return sequences
-        .into_iter()
-        .map(|value_vec| usize_vec_to_string(value_vec))
-        .collect();
-}
-
-fn usize_vec_to_string(values: Vec<usize>) -> String {
-    values
-        .into_iter()
-        .map(|value| get_coin_name(value))
-        .collect::<String>()
+    sequences
 }
 
 fn _get_valid_sequences_with_defaults(
@@ -48,7 +38,7 @@ fn _get_valid_sequences_with_defaults(
     counts: &[usize],
     current_sequence: &mut Vec<usize>,
     clock_state: &mut Vec<bool>,
-    return_values: &mut Vec<Vec<usize>>,
+    return_values: &mut Vec<String>,
 ) {
     _get_valid_sequences(
         num_hours,
@@ -68,12 +58,12 @@ fn _get_valid_sequences(
     counts: &[usize],
     current_sequence: &mut Vec<usize>,
     clock_state: &mut Vec<bool>,
-    return_values: &mut Vec<Vec<usize>>,
+    return_values: &mut Vec<String>,
     current_value: usize,
     current_counts: &mut Vec<usize>,
 ) {
     if current_sequence.len() == num_hours {
-        return_values.push(current_sequence.to_owned());
+        return_values.push(current_sequence.iter().map(|&v| get_coin_name(v)).collect());
     } else {
         for i in 0..coins.len() {
             let counts_remaining = counts[i] - current_counts[i];
@@ -112,11 +102,11 @@ fn _get_valid_sequences(
 }
 
 fn get_coin_name(coin_value: usize) -> char {
-    return match coin_value {
+    match coin_value {
         1 => 'p',
         5 => 'n',
         10 => 'd',
         25 => 'q',
         _ => 'x',
-    };
+    }
 }


### PR DESCRIPTION
**This PR**
Updates the API for the inner "get valid sequences" to be less "weird".
Updates the Go code to allocate one return value slice beforehand and pass it around.

**Why?**
Having the return type of "list of lists of ints" was arguably weird. And then writing functions to turn lists of lists of ints into lists of strings was also weird. Since we're going to have to convert list of ints to strings exactly once per valid result and we're not currently threading, it doesn't matter where this happens and I thought it was better in the inner function. Also, if I ever add concurrency, it could be faster the way it is now.

Updated the Go code to have the same memory allocation scheme as the others ... I hope.

Where | Results
-|-
master | ![master](https://user-images.githubusercontent.com/18740355/77337867-e43ec280-6cff-11ea-9614-c3c41c21739e.png)
branch | ![branch](https://user-images.githubusercontent.com/18740355/77337871-e739b300-6cff-11ea-8636-ccc6c4e114f1.png)
