### PR TITLE
Uses a u16 for the clock state

### DIFF
--- a/coins-on-the-clock/rust/assembly.s
+++ b/coins-on-the-clock/rust/assembly.s
@@ -150,24 +150,22 @@ alloc::vec::Vec<T>::reserve:
         .long   32
 example::get_valid_sequences:
         push    rbx
-        sub     rsp, 128
+        sub     rsp, 112
         mov     rbx, rdi
         mov     qword ptr [rsp + 8], 8
         xorps   xmm0, xmm0
         movups  xmmword ptr [rsp + 16], xmm0
         movaps  xmm0, xmmword ptr [rip + .LCPI3_0]
-        movaps  xmmword ptr [rsp + 48], xmm0
-        mov     qword ptr [rsp + 64], 4
+        movaps  xmmword ptr [rsp + 32], xmm0
+        mov     qword ptr [rsp + 48], 4
         movaps  xmm0, xmmword ptr [rip + .LCPI3_1]
+        movaps  xmmword ptr [rsp + 64], xmm0
         movaps  xmmword ptr [rsp + 80], xmm0
         movaps  xmmword ptr [rsp + 96], xmm0
-        movaps  xmmword ptr [rsp + 112], xmm0
-        mov     dword ptr [rsp + 40], 0
-        mov     qword ptr [rsp + 32], 0
-        lea     rdi, [rsp + 48]
-        lea     rsi, [rsp + 80]
-        lea     rdx, [rsp + 32]
+        lea     rdi, [rsp + 32]
+        lea     rsi, [rsp + 64]
         lea     rcx, [rsp + 8]
+        xor     edx, edx
         xor     r8d, r8d
         xor     r9d, r9d
         call    example::_get_valid_sequences
@@ -176,7 +174,7 @@ example::get_valid_sequences:
         movups  xmm0, xmmword ptr [rsp + 8]
         movups  xmmword ptr [rbx], xmm0
         mov     rax, rbx
-        add     rsp, 128
+        add     rsp, 112
         pop     rbx
         ret
         mov     rbx, rax
@@ -194,51 +192,51 @@ example::_get_valid_sequences:
         push    r12
         push    rbx
         sub     rsp, 72
-        mov     r15, r8
-        mov     rbp, rcx
-        mov     r13, rdx
-        mov     r12, rsi
+        mov     r12, r9
+        mov     r13, r8
+        mov     qword ptr [rsp + 64], rcx
+        mov     ebp, edx
+        mov     r15, rsi
         mov     rbx, rdi
         cmp     qword ptr [rdi], 0
-        mov     qword ptr [rsp + 24], rcx
         jne     .LBB4_1
         mov     rax, qword ptr [rbx + 8]
         or      rax, qword ptr [rbx + 16]
         jne     .LBB4_1
-        mov     qword ptr [rsp], 1
+        mov     qword ptr [rsp + 8], 1
         xorps   xmm0, xmm0
-        movups  xmmword ptr [rsp + 8], xmm0
-        mov     rdi, rsp
+        movups  xmmword ptr [rsp + 16], xmm0
+        lea     rdi, [rsp + 8]
         mov     esi, 12
         call    alloc::vec::Vec<T>::reserve
         xor     ebx, ebx
-        mov     r15, rsp
+        lea     r12, [rsp + 8]
         lea     r14, [rsp + 32]
         mov     r13, qword ptr [rip + memcpy@GOTPCREL]
-        mov     ebp, dword ptr [r12 + rbx]
+        mov     ebp, dword ptr [r15 + rbx]
         cmp     ebp, 128
         jb      .LBB4_27
         jmp     .LBB4_21
 .LBB4_29:
-        mov     rax, qword ptr [rsp + 16]
+        mov     rax, qword ptr [rsp + 24]
 .LBB4_30:
-        mov     rcx, qword ptr [rsp]
+        mov     rcx, qword ptr [rsp + 8]
         mov     byte ptr [rcx + rax], bpl
         add     rax, 1
-        mov     qword ptr [rsp + 16], rax
+        mov     qword ptr [rsp + 24], rax
         add     rbx, 4
         cmp     rbx, 48
         je      .LBB4_32
 .LBB4_20:
-        mov     ebp, dword ptr [r12 + rbx]
+        mov     ebp, dword ptr [r15 + rbx]
         cmp     ebp, 128
         jae     .LBB4_21
 .LBB4_27:
-        mov     rax, qword ptr [rsp + 16]
-        cmp     rax, qword ptr [rsp + 8]
+        mov     rax, qword ptr [rsp + 24]
+        cmp     rax, qword ptr [rsp + 16]
         jne     .LBB4_30
         mov     esi, 1
-        mov     rdi, r15
+        mov     rdi, r12
         call    alloc::vec::Vec<T>::reserve
         jmp     .LBB4_29
 .LBB4_21:
@@ -291,13 +289,13 @@ example::_get_valid_sequences:
         mov     byte ptr [rsp + 35], bpl
         mov     ebp, 4
 .LBB4_25:
-        mov     rdi, r15
+        mov     rdi, r12
         mov     rsi, rbp
         call    alloc::vec::Vec<T>::reserve
-        mov     rdi, qword ptr [rsp + 16]
+        mov     rdi, qword ptr [rsp + 24]
         lea     rax, [rdi + rbp]
-        mov     qword ptr [rsp + 16], rax
-        add     rdi, qword ptr [rsp]
+        mov     qword ptr [rsp + 24], rax
+        add     rdi, qword ptr [rsp + 8]
         mov     rsi, r14
         mov     rdx, rbp
         call    r13
@@ -305,13 +303,13 @@ example::_get_valid_sequences:
         cmp     rbx, 48
         jne     .LBB4_20
 .LBB4_32:
-        mov     rax, qword ptr [rsp + 16]
+        mov     rax, qword ptr [rsp + 24]
         mov     qword ptr [rsp + 48], rax
-        movups  xmm0, xmmword ptr [rsp]
+        movups  xmm0, xmmword ptr [rsp + 8]
         movaps  xmmword ptr [rsp + 32], xmm0
-        mov     rdi, qword ptr [rsp + 24]
-        mov     rsi, qword ptr [rdi + 16]
-        cmp     rsi, qword ptr [rdi + 8]
+        mov     rbp, qword ptr [rsp + 64]
+        mov     rsi, qword ptr [rbp + 16]
+        cmp     rsi, qword ptr [rbp + 8]
         jne     .LBB4_33
         mov     rax, rsi
         inc     rax
@@ -322,7 +320,7 @@ example::_get_valid_sequences:
         mov     ecx, 24
         xor     ebx, ebx
         mul     rcx
-        mov     rbp, rax
+        mov     r15, rax
         setno   al
         jo      .LBB4_51
         mov     bl, al
@@ -336,166 +334,162 @@ example::_get_valid_sequences:
         mov     dl, al
         shl     rdx, 3
         lea     rsi, [rsi + 2*rsi]
-        mov     rax, qword ptr [rsp + 24]
-        mov     rdi, qword ptr [rax]
-        mov     qword ptr [rsp], rsi
-        mov     qword ptr [rsp + 8], rdx
+        mov     rdi, qword ptr [rbp]
+        mov     qword ptr [rsp + 8], rsi
+        mov     qword ptr [rsp + 16], rdx
         test    rsi, rsi
         je      .LBB4_43
-        test    rbp, rbp
+        test    r15, r15
         je      .LBB4_48
-        mov     rcx, rbp
+        mov     rcx, r15
         call    qword ptr [rip + __rust_realloc@GOTPCREL]
         mov     rcx, rax
         test    rax, rax
         jne     .LBB4_50
-        jmp     .LBB4_65
+        jmp     .LBB4_63
 .LBB4_1:
-        mov     rax, qword ptr [rbx]
-        cmp     r9, 12
+        mov     rsi, qword ptr [rbx]
+        cmp     r12, 12
         jae     .LBB4_2
-        lea     r10, [r9 + 1]
-        test    rax, rax
+        lea     r14, [r12 + 1]
+        test    rsi, rsi
         je      .LBB4_9
-        lea     r14, [r15 + 1]
+        lea     r8, [r13 + 1]
         movabs  rcx, -6148914691236517205
-        mov     rax, r14
+        mov     rax, r8
         mul     rcx
         shr     rdx
         and     rdx, -4
         lea     rax, [rdx + 2*rdx]
-        sub     r14, rax
-        cmp     byte ptr [r13 + r14], 0
-        jne     .LBB4_9
-        mov     byte ptr [r13 + r14], 1
-        add     qword ptr [rbx], -1
-        mov     dword ptr [r12 + 4*r9], 112
+        sub     r8, rax
+        mov     edx, 1
+        mov     ecx, r8d
+        shl     edx, cl
+        bt      ebp, r8d
+        jb      .LBB4_9
+        add     rsi, -1
+        mov     qword ptr [rbx], rsi
+        mov     dword ptr [r15 + 4*r12], 112
+        or      edx, ebp
         mov     rdi, rbx
-        mov     rsi, r12
-        mov     rdx, r13
-        mov     rcx, rbp
-        mov     r8, r14
-        mov     qword ptr [rsp + 56], r9
-        mov     r9, r10
-        mov     qword ptr [rsp + 64], r10
+        mov     rsi, r15
+        mov     rcx, qword ptr [rsp + 64]
+        mov     r9, r14
         call    example::_get_valid_sequences
-        mov     r10, qword ptr [rsp + 64]
-        mov     r9, qword ptr [rsp + 56]
-        mov     byte ptr [r13 + r14], 0
         add     qword ptr [rbx], 1
 .LBB4_9:
-        cmp     qword ptr [rbx + 8], 0
+        mov     rsi, qword ptr [rbx + 8]
+        test    rsi, rsi
         je      .LBB4_12
-        lea     rbp, [r15 + 5]
+        lea     r8, [r13 + 5]
         movabs  rcx, -6148914691236517205
-        mov     rax, rbp
+        mov     rax, r8
         mul     rcx
         shr     rdx
         and     rdx, -4
         lea     rax, [rdx + 2*rdx]
-        sub     rbp, rax
-        cmp     byte ptr [r13 + rbp], 0
-        jne     .LBB4_12
-        mov     byte ptr [r13 + rbp], 1
-        add     qword ptr [rbx + 8], -1
-        mov     dword ptr [r12 + 4*r9], 110
+        sub     r8, rax
+        mov     edx, 1
+        mov     ecx, r8d
+        shl     edx, cl
+        bt      ebp, r8d
+        jb      .LBB4_12
+        add     rsi, -1
+        mov     qword ptr [rbx + 8], rsi
+        mov     dword ptr [r15 + 4*r12], 110
+        or      edx, ebp
         mov     rdi, rbx
-        mov     rsi, r12
-        mov     rdx, r13
-        mov     rcx, qword ptr [rsp + 24]
-        mov     r8, rbp
-        mov     qword ptr [rsp + 56], r9
-        mov     r9, r10
-        mov     r14, r10
+        mov     rsi, r15
+        mov     rcx, qword ptr [rsp + 64]
+        mov     r9, r14
         call    example::_get_valid_sequences
-        mov     r10, r14
-        mov     r9, qword ptr [rsp + 56]
-        mov     byte ptr [r13 + rbp], 0
         add     qword ptr [rbx + 8], 1
 .LBB4_12:
-        cmp     qword ptr [rbx + 16], 0
+        mov     rsi, qword ptr [rbx + 16]
+        test    rsi, rsi
         je      .LBB4_15
-        add     r15, 10
+        add     r13, 10
         movabs  rcx, -6148914691236517205
-        mov     rax, r15
+        mov     rax, r13
         mul     rcx
         shr     rdx
         and     rdx, -4
         lea     rax, [rdx + 2*rdx]
-        sub     r15, rax
-        cmp     byte ptr [r13 + r15], 0
-        jne     .LBB4_15
-        mov     byte ptr [r13 + r15], 1
-        add     qword ptr [rbx + 16], -1
-        mov     dword ptr [r12 + 4*r9], 100
+        sub     r13, rax
+        mov     edx, 1
+        mov     ecx, r13d
+        shl     edx, cl
+        bt      ebp, r13d
+        jb      .LBB4_15
+        add     rsi, -1
+        mov     qword ptr [rbx + 16], rsi
+        mov     dword ptr [r15 + 4*r12], 100
+        or      edx, ebp
         mov     rdi, rbx
-        mov     rsi, r12
-        mov     rdx, r13
-        mov     rcx, qword ptr [rsp + 24]
-        mov     r8, r15
-        mov     r9, r10
+        mov     rsi, r15
+        mov     rcx, qword ptr [rsp + 64]
+        mov     r8, r13
+        mov     r9, r14
         call    example::_get_valid_sequences
-        mov     byte ptr [r13 + r15], 0
         add     qword ptr [rbx + 16], 1
         jmp     .LBB4_15
 .LBB4_33:
-        mov     rcx, qword ptr [rdi]
+        mov     rcx, qword ptr [rbp]
         jmp     .LBB4_34
 .LBB4_38:
-        mov     qword ptr [rsp], rbp
-        mov     qword ptr [rsp + 8], rbx
-        test    rbp, rbp
+        mov     qword ptr [rsp + 8], r15
+        mov     qword ptr [rsp + 16], rbx
+        test    r15, r15
         je      .LBB4_41
-        mov     rdi, rbp
+        mov     rdi, r15
         mov     rsi, rbx
         call    qword ptr [rip + __rust_alloc@GOTPCREL]
         mov     rcx, rax
         test    rax, rax
         jne     .LBB4_50
-        jmp     .LBB4_65
+        jmp     .LBB4_63
 .LBB4_43:
-        test    rbp, rbp
+        test    r15, r15
         je      .LBB4_44
-        mov     rdi, rbp
+        mov     rdi, r15
         mov     rsi, rdx
         call    qword ptr [rip + __rust_alloc@GOTPCREL]
         mov     rcx, rax
         test    rax, rax
         jne     .LBB4_50
-        jmp     .LBB4_65
+        jmp     .LBB4_63
 .LBB4_48:
-        mov     r14, rsp
+        lea     r14, [rsp + 8]
         call    qword ptr [rip + __rust_dealloc@GOTPCREL]
         mov     rdi, r14
         call    qword ptr [rip + core::alloc::Layout::dangling@GOTPCREL]
         jmp     .LBB4_49
 .LBB4_41:
-        mov     rdi, rsp
+        lea     rdi, [rsp + 8]
         call    qword ptr [rip + core::alloc::Layout::dangling@GOTPCREL]
         jmp     .LBB4_49
 .LBB4_44:
-        mov     rdi, rsp
+        lea     rdi, [rsp + 8]
         call    qword ptr [rip + core::alloc::Layout::dangling@GOTPCREL]
 .LBB4_49:
         mov     rcx, rax
         test    rax, rax
-        je      .LBB4_65
+        je      .LBB4_63
 .LBB4_50:
         movabs  rdx, -6148914691236517205
-        mov     rax, rbp
+        mov     rax, r15
         mul     rdx
         shr     rdx, 4
-        mov     rdi, qword ptr [rsp + 24]
-        mov     qword ptr [rdi], rcx
-        mov     qword ptr [rdi + 8], rdx
-        mov     rsi, qword ptr [rdi + 16]
+        mov     qword ptr [rbp], rcx
+        mov     qword ptr [rbp + 8], rdx
+        mov     rsi, qword ptr [rbp + 16]
 .LBB4_34:
         lea     rax, [rsi + 2*rsi]
         mov     rdx, qword ptr [rsp + 48]
         mov     qword ptr [rcx + 8*rax + 16], rdx
         movaps  xmm0, xmmword ptr [rsp + 32]
         movups  xmmword ptr [rcx + 8*rax], xmm0
-        add     qword ptr [rdi + 16], 1
+        add     qword ptr [rbp + 16], 1
 .LBB4_15:
         add     rsp, 72
         pop     rbx
@@ -506,67 +500,62 @@ example::_get_valid_sequences:
         pop     rbp
         ret
 .LBB4_2:
-        movabs  rsi, -6148914691236517205
-        test    rax, rax
+        movabs  rdi, -6148914691236517205
+        test    rsi, rsi
         je      .LBB4_3
-        lea     rcx, [r15 + 1]
+        lea     rcx, [r13 + 1]
         mov     rax, rcx
-        mul     rsi
-        shr     rdx
-        and     rdx, -4
-        lea     rax, [rdx + 2*rdx]
-        sub     rcx, rax
-        cmp     byte ptr [r13 + rcx], 0
-        je      .LBB4_54
+        mul     rdi
+        shr     edx
+        and     edx, -4
+        lea     eax, [rdx + 2*rdx]
+        sub     ecx, eax
+        bt      ebp, ecx
+        jae     .LBB4_54
 .LBB4_3:
-        cmp     qword ptr [rbx + 8], 0
-        je      .LBB4_57
-        lea     rcx, [r15 + 5]
+        mov     rsi, qword ptr [rbx + 8]
+        test    rsi, rsi
+        je      .LBB4_55
+        lea     rcx, [r13 + 5]
         mov     rax, rcx
-        mul     rsi
-        shr     rdx
-        and     rdx, -4
-        lea     rax, [rdx + 2*rdx]
-        sub     rcx, rax
-        cmp     byte ptr [r13 + rcx], 0
-        je      .LBB4_5
-.LBB4_57:
-        cmp     qword ptr [rbx + 16], 0
+        mul     rdi
+        shr     edx
+        and     edx, -4
+        lea     eax, [rdx + 2*rdx]
+        sub     ecx, eax
+        bt      ebp, ecx
+        jae     .LBB4_5
+.LBB4_55:
+        mov     rsi, qword ptr [rbx + 16]
+        test    rsi, rsi
         je      .LBB4_15
-        add     r15, 10
-        mov     rax, r15
-        mul     rsi
-        shr     rdx
-        and     rdx, -4
-        lea     rax, [rdx + 2*rdx]
-        sub     r15, rax
-        cmp     byte ptr [r13 + r15], 0
-        jne     .LBB4_15
-        mov     rsi, r9
+        add     r13, 10
+        mov     rax, r13
+        mul     rdi
+        shr     edx
+        and     edx, -4
+        lea     eax, [rdx + 2*rdx]
+        sub     r13d, eax
+        bt      ebp, r13d
+        jb      .LBB4_15
         add     rbx, 16
-        add     r13, r15
-        jmp     .LBB4_56
+        jmp     .LBB4_54
 .LBB4_51:
         call    qword ptr [rip + alloc::raw_vec::capacity_overflow@GOTPCREL]
         ud2
-.LBB4_65:
-        mov     rdi, rbp
+.LBB4_63:
+        mov     rdi, r15
         mov     rsi, rbx
         call    qword ptr [rip + alloc::alloc::handle_alloc_error@GOTPCREL]
         ud2
-.LBB4_54:
-        mov     rsi, r9
-        jmp     .LBB4_55
 .LBB4_5:
-        mov     rsi, r9
         add     rbx, 8
-.LBB4_55:
-        add     r13, rcx
-.LBB4_56:
-        mov     byte ptr [r13], 1
-        add     qword ptr [rbx], -1
+.LBB4_54:
+        add     rsi, -1
+        mov     qword ptr [rbx], rsi
         lea     rdi, [rip + .L__unnamed_1]
         mov     edx, 12
+        mov     rsi, r12
         call    qword ptr [rip + core::panicking::panic_bounds_check@GOTPCREL]
         ud2
         mov     rbx, rax
@@ -578,7 +567,7 @@ example::_get_valid_sequences:
         jmp     .LBB4_18
 .LBB4_18:
         mov     rbx, rax
-        mov     rdi, rsp
+        lea     rdi, [rsp + 8]
         call    core::ptr::drop_in_place
         mov     rdi, rbx
         call    _Unwind_Resume@PLT
@@ -589,4 +578,4 @@ example::_get_valid_sequences:
 
 .L__unnamed_1:
         .quad   .L__unnamed_2
-        .asciz  "\f\000\000\000\000\000\000\000-\000\000\000\r\000\000"
+        .asciz  "\f\000\000\000\000\000\000\000,\000\000\000\r\000\000"

--- a/coins-on-the-clock/rust/src/lib.rs
+++ b/coins-on-the-clock/rust/src/lib.rs
@@ -8,7 +8,7 @@ pub fn get_valid_sequences() -> Vec<String> {
     _get_valid_sequences(
         &mut [4, 4, 4],
         &mut [' '; NUM_HOURS],
-        &mut [false; NUM_HOURS],
+        0,
         &mut sequences,
         0,
         0,
@@ -20,7 +20,7 @@ pub fn get_valid_sequences() -> Vec<String> {
 fn _get_valid_sequences(
     counts: &mut [usize; 3],
     current_sequence: &mut [char; NUM_HOURS],
-    clock_state: &mut [bool; NUM_HOURS],
+    clock_state: u16,
     return_values: &mut Vec<String>,
     current_value: usize,
     current_index: usize,
@@ -36,24 +36,22 @@ fn _get_valid_sequences(
             let coin = COINS[i];
             let next_value = (current_value + coin) % NUM_HOURS;
 
-            if clock_state[next_value] {
+            if clock_state & (1 << next_value) != 0 {
                 continue;
             }
 
-            clock_state[next_value] = true;
             counts[i] -= 1;
             current_sequence[current_index] = COIN_CHARS[i];
 
             _get_valid_sequences(
                 counts,
                 current_sequence,
-                clock_state,
+                clock_state | (1 << next_value),
                 return_values,
                 next_value,
                 current_index + 1,
             );
 
-            clock_state[next_value] = false;
             counts[i] += 1;
         }
     }


### PR DESCRIPTION
**This PR**
Attempts to improve performance by using a `u16` instead of a `[bool: NUM_HOURS]` for the clock state

**Results**
```
coins on the clock      time:   [31.006 us 31.055 us 31.110 us]
                        change: [+45.359% +47.354% +49.213%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
```
Fail!