### PR TITLE
Unrolls loop

### DIFF
--- a/coins-on-the-clock/rust/src/lib.rs
+++ b/coins-on-the-clock/rust/src/lib.rs
@@ -1,12 +1,18 @@
 const NUM_HOURS: usize = 12;
-const COINS: [usize; 3] = [1, 5, 10];
-const COIN_CHARS: [char; 3] = ['p', 'n', 'd'];
+const PENNY: char = 'p';
+const PENNY_VALUE: usize = 1;
+const NICKEL: char = 'n';
+const NICKEL_VALUE: usize = 5;
+const DIME: char = 'd';
+const DIME_VALUE: usize = 10;
 
 pub fn get_valid_sequences() -> Vec<String> {
     let mut sequences = Vec::new();
 
     _get_valid_sequences(
-        &mut [4, 4, 4],
+        4,
+        4,
+        4,
         &mut [' '; NUM_HOURS],
         &mut [false; NUM_HOURS],
         &mut sequences,
@@ -18,43 +24,77 @@ pub fn get_valid_sequences() -> Vec<String> {
 }
 
 fn _get_valid_sequences(
-    counts: &mut [usize; 3],
+    num_pennies: u8,
+    num_nickels: u8,
+    num_dimes: u8,
     current_sequence: &mut [char; NUM_HOURS],
     clock_state: &mut [bool; NUM_HOURS],
     return_values: &mut Vec<String>,
     current_value: usize,
     current_index: usize,
 ) {
-    if counts.iter().all(|&n| n == 0) {
+    if num_pennies == 0 && num_nickels == 0 && num_dimes == 0 {
         return_values.push(current_sequence.iter().collect());
     } else {
-        for i in 0..COINS.len() {
-            if counts[i] == 0 {
-                continue;
+        if num_pennies != 0 {
+            let next_value = (current_value + PENNY_VALUE) % NUM_HOURS;
+            if !clock_state[next_value] {
+                clock_state[next_value] = true;
+                current_sequence[current_index] = PENNY;
+
+                _get_valid_sequences(
+                    num_pennies - 1,
+                    num_nickels,
+                    num_dimes,
+                    current_sequence,
+                    clock_state,
+                    return_values,
+                    next_value,
+                    current_index + 1,
+                );
+
+                clock_state[next_value] = false;
             }
+        }
+        if num_nickels != 0 {
+            let next_value = (current_value + NICKEL_VALUE) % NUM_HOURS;
+            if !clock_state[next_value] {
+                clock_state[next_value] = true;
+                current_sequence[current_index] = NICKEL;
 
-            let coin = COINS[i];
-            let next_value = (current_value + coin) % NUM_HOURS;
+                _get_valid_sequences(
+                    num_pennies,
+                    num_nickels - 1,
+                    num_dimes,
+                    current_sequence,
+                    clock_state,
+                    return_values,
+                    next_value,
+                    current_index + 1,
+                );
 
-            if clock_state[next_value] {
-                continue;
+                clock_state[next_value] = false;
             }
+        }
+        if num_dimes != 0 {
+            let next_value = (current_value + DIME_VALUE) % NUM_HOURS;
+            if !clock_state[next_value] {
+                clock_state[next_value] = true;
+                current_sequence[current_index] = DIME;
 
-            clock_state[next_value] = true;
-            counts[i] -= 1;
-            current_sequence[current_index] = COIN_CHARS[i];
+                _get_valid_sequences(
+                    num_pennies,
+                    num_nickels,
+                    num_dimes - 1,
+                    current_sequence,
+                    clock_state,
+                    return_values,
+                    next_value,
+                    current_index + 1,
+                );
 
-            _get_valid_sequences(
-                counts,
-                current_sequence,
-                clock_state,
-                return_values,
-                next_value,
-                current_index + 1,
-            );
-
-            clock_state[next_value] = false;
-            counts[i] += 1;
+                clock_state[next_value] = false;
+            }
         }
     }
 }


### PR DESCRIPTION
**This PR**
Attempts to improve performance by unrolling the loop and splitting out the coin numbers.

**Results**
```
coins on the clock      time:   [20.809 us 20.899 us 20.993 us]
                        change: [+1.6131% +3.2071% +4.4782%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```
Fail!